### PR TITLE
fix: let the upload run when no board is selected

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/user-fields.ts
+++ b/arduino-ide-extension/src/browser/contributions/user-fields.ts
@@ -74,7 +74,9 @@ export class UserFields extends Contribution {
   async checkUserFieldsDialog(forceOpen = false): Promise<boolean> {
     const key = this.selectedFqbnAddress();
     if (!key) {
-      return false;
+      // Let the upload continue without an FQBN and the CLI fail instead of disabling the upload from IDE.
+      // https://github.com/arduino/arduino-ide/issues/1714
+      return true;
     }
     /*
       If the board requires to be configured with user fields, we want


### PR DESCRIPTION
IDE2 must not disable the upload from the UI when no board is selected. Otherwise, IDE2 does not receive the `no FQBN` error from the CLI and cannot cannot
suggest selecting a board via the `Tools` > `Board` menu.

Closes arduino/arduino-ide#1714

### Motivation

<!-- Why this pull request? -->

### Change description

<!-- What does your code do? -->

### Other information

<!-- Any additional information that could help the review process -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
